### PR TITLE
Make stringified user props match actual prop names

### DIFF
--- a/venmo_api/models/user.py
+++ b/venmo_api/models/user.py
@@ -63,6 +63,6 @@ class User(object):
                    is_active=parser.get_is_active())
 
     def __str__(self):
-        return f'id: {self.id}, username: {self.username}, firstname: {self.first_name}, lastname: {self.last_name}'\
-            f' display_name: {self.display_name}, phone: {self.phone}, picture: {self.profile_picture_url}, about: {self.about},'\
+        return f'id: {self.id}, username: {self.username}, first_name: {self.first_name}, last_name: {self.last_name}'\
+            f' display_name: {self.display_name}, phone: {self.phone}, profile_picture_url: {self.profile_picture_url}, about: {self.about},'\
             f' joined: {self.date_joined}, is_group: {self.is_group}, is_active: {self.is_active}'


### PR DESCRIPTION
This PR just changes the user model's `__str__` to use the actual names of the properties of the `User` object so that it's easier to figure out what they correspond to if you want to access them separately.

This tripped me up since I was looking for a `firstname` property on a user object after viewing its string representation, but that didn't exist – it was `first_name`.

This is a super cool project, by the way! I've been looking for something like this for a long time.