### PR TITLE
Add expired status for paymentStatus

### DIFF
--- a/venmo_api/models/payment.py
+++ b/venmo_api/models/payment.py
@@ -68,3 +68,4 @@ class PaymentStatus(Enum):
     CANCELLED = 'cancelled'
     PENDING = 'pending'
     FAILED = 'failed'
+    EXPIRED = 'expired'


### PR DESCRIPTION
Requests for payment time out after 31 (?) days and have a status of "expired.".

If you have an expired payment in your history, `get_pay_payments` method errors out with `ValueError: 'expired' is not a valid PaymentStatus`.

Adding the enum for expired payments resolves this.

Fixes: #28 