### PR TITLE
Two minor improvements - `quiet` variable and using stderr

### DIFF
--- a/venmo_api/apis/auth_api.py
+++ b/venmo_api/apis/auth_api.py
@@ -1,4 +1,4 @@
-from venmo_api import random_device_id, warn, confirm, AuthenticationFailedError, ApiClient
+from venmo_api import random_device_id, message, warn, confirm, AuthenticationFailedError, ApiClient
 
 
 class AuthenticationApi(object):
@@ -22,9 +22,9 @@ class AuthenticationApi(object):
         # Give warnings to the user about device-id and token expiration
         if not quiet:
             warn("IMPORTANT: Take a note of your device-id to avoid 2-factor-authentication for your next login.")
-            print(f"device-id: {self.__device_id}")
-            warn("IMPORTANT: Your Access Token will NEVER expire, unless you logout manually (client.log_out(token)).\n"
-                "Take a note of your token, so you don't have to login every time.\n")
+            message(f"device-id: {self.__device_id}")
+            warn("IMPORTANT: Your Access Token will NEVER expire, unless you logout manually (client.log_out(token)).")
+            warn("Take a note of your token, so you don't have to login every time.")
 
         response = self.authenticate_using_username_password(username, password)
 
@@ -38,8 +38,8 @@ class AuthenticationApi(object):
 
         if not quiet:
             confirm("Successfully logged in. Note your token and device-id")
-            print(f"access_token: {access_token}\n"
-                f"device-id: {self.__device_id}")
+            message(f"access_token: {access_token}")
+            message(f"device-id: {self.__device_id}")
 
         return access_token
 
@@ -165,7 +165,7 @@ class AuthenticationApi(object):
                                    method='POST')
 
         confirm(f"Successfully added your device id to the list of the trusted devices.")
-        print(f"Use the same device-id: {self.__device_id} next time to avoid 2-factor-auth process.")
+        message(f"Use the same device-id: {self.__device_id} next time to avoid 2-factor-auth process.")
 
     def get_device_id(self):
         return self.__device_id

--- a/venmo_api/apis/auth_api.py
+++ b/venmo_api/apis/auth_api.py
@@ -11,7 +11,7 @@ class AuthenticationApi(object):
         self.__device_id = device_id or random_device_id()
         self.__api_client = api_client or ApiClient()
 
-    def login_with_credentials_cli(self, username: str, password: str) -> str:
+    def login_with_credentials_cli(self, username: str, password: str, quiet: bool=False) -> str:
         """
         Pass your username and password to get an access_token for using the API.
         :param username: <str> Phone, email or username
@@ -20,23 +20,26 @@ class AuthenticationApi(object):
         """
 
         # Give warnings to the user about device-id and token expiration
-        warn("IMPORTANT: Take a note of your device-id to avoid 2-factor-authentication for your next login.")
-        print(f"device-id: {self.__device_id}")
-        warn("IMPORTANT: Your Access Token will NEVER expire, unless you logout manually (client.log_out(token)).\n"
-             "Take a note of your token, so you don't have to login every time.\n")
+        if not quiet:
+            warn("IMPORTANT: Take a note of your device-id to avoid 2-factor-authentication for your next login.")
+            print(f"device-id: {self.__device_id}")
+            warn("IMPORTANT: Your Access Token will NEVER expire, unless you logout manually (client.log_out(token)).\n"
+                "Take a note of your token, so you don't have to login every time.\n")
 
         response = self.authenticate_using_username_password(username, password)
 
         # if two-factor error
         if response.get('body').get('error'):
+            # note: this should print to stderr even if `quiet=True`
             access_token = self.__two_factor_process_cli(response=response)
             self.trust_this_device()
         else:
             access_token = response['body']['access_token']
 
-        confirm("Successfully logged in. Note your token and device-id")
-        print(f"access_token: {access_token}\n"
-             f"device-id: {self.__device_id}")
+        if not quiet:
+            confirm("Successfully logged in. Note your token and device-id")
+            print(f"access_token: {access_token}\n"
+                f"device-id: {self.__device_id}")
 
         return access_token
 

--- a/venmo_api/utils/api_util.py
+++ b/venmo_api/utils/api_util.py
@@ -1,3 +1,4 @@
+import sys
 from venmo_api import ArgumentMissingError, User, Page
 from enum import Enum
 from typing import Dict, List
@@ -94,22 +95,30 @@ class Colors(Enum):
     UNDERLINE = '\033[4m'
 
 
-def warn(message):
+def warn(message: str) -> None:
     """
     print message in Red Color
     :param message:
     :return:
     """
-    print(Colors.WARNING.value + message + Colors.ENDC.value)
+    message(Colors.WARNING.value + message + Colors.ENDC.value)
 
 
-def confirm(message):
+def confirm(message: str) -> None:
     """
     print message in Blue Color
     :param message:
     :return:
     """
-    print(Colors.OKBLUE.value + message + Colors.ENDC.value)
+    message(Colors.OKBLUE.value + message + Colors.ENDC.value)
+
+def message(message: str) -> None:
+    """
+    print message for user
+    : param message:
+    :return:
+    """
+    print(message, file=sys.stderr)
 
 
 def get_user_id(user, user_id):

--- a/venmo_api/venmo.py
+++ b/venmo_api/venmo.py
@@ -27,7 +27,7 @@ class Client(object):
         return self.__profile
 
     @staticmethod
-    def get_access_token(username: str, password: str, device_id: str = None) -> str:
+    def get_access_token(username: str, password: str, device_id: str = None, quiet: bool=False) -> str:
         """
         Log in using your credentials and get an access_token to use in the API
         :param username: <str> Can be username, phone number (without +1) or email address.
@@ -37,7 +37,7 @@ class Client(object):
         :return: <str> access_token
         """
         authn_api = AuthenticationApi(api_client=ApiClient(), device_id=device_id)
-        return authn_api.login_with_credentials_cli(username=username, password=password)
+        return authn_api.login_with_credentials_cli(username=username, password=password, quiet=quiet)
 
     @staticmethod
     def log_out(access_token) -> bool:


### PR DESCRIPTION
## Quiet Variable

The quiet variable, in particular, is important when being used as a library. Users might not want to see so much content. The 2FA OTP is the one thing that always needs to be shown. By default, I left the verbosity as-is, and just added a command-line flag to turn it off.

## stderr

Right now, most regular output is going to stdout. Status updates intended for the user should go to stderr rather than stdout. stdout should be for actual data that was returned by an intended command, not these status update messages.