### PR TITLE
Two Factor Authentication without CLI

### DIFF
--- a/venmo_api/apis/auth_api.py
+++ b/venmo_api/apis/auth_api.py
@@ -1,4 +1,5 @@
 from venmo_api import random_device_id, warn, confirm, AuthenticationFailedError, ApiClient
+from collections.abc import Callable, Awaitable
 
 
 class AuthenticationApi(object):
@@ -39,6 +40,37 @@ class AuthenticationApi(object):
              f"device-id: {self.__device_id}")
 
         return access_token
+    
+    def login_with_credentials_func(self, username: str, password: str, otp_func: Callable[[], str]) -> str:
+        """
+        Pass your username and password to get an access_token for using the API.
+        :param username: <str> Phone, email or username
+        :param password: <str> Your account password to login
+        :param otp_func: <Callable[[], str]> Function that returns the OTP provided to the user
+        :return: <str>
+        """
+        
+        # Give warnings to the user about device-id and token expiration
+        warn("IMPORTANT: Take a note of your device-id to avoid 2-factor-authentication for your next login.")
+        print(f"device-id: {self.__device_id}")
+        warn("IMPORTANT: Your Access Token will NEVER expire, unless you logout manually (client.log_out(token)).\n"
+             "Take a note of your token, so you don't have to login every time.\n")
+        
+        response = self.authenticate_using_username_password(username, password)
+        
+        # if two-factor error
+        if response.get('body').get('error'):
+            access_token = self.__two_factor_process_func(response=response, otp_func=otp_func)
+            
+            self.trust_this_device()
+        else:
+            access_token = response['body']['access_token']
+            
+        confirm("Successfully logged in. Note your token and device-id")
+        print(f"access_token: {access_token}\n"
+             f"device-id: {self.__device_id}")
+        
+        return access_token
 
     @staticmethod
     def log_out(access_token: str) -> bool:
@@ -75,6 +107,27 @@ class AuthenticationApi(object):
         access_token = self.authenticate_using_otp(user_otp, otp_secret)
         self.__api_client.update_access_token(access_token=access_token)
 
+        return access_token
+
+    def __two_factor_process_func(self, response: dict, otp_func: Callable[[], str] = None) -> str:
+        """
+        Get response from authenticate_with_username_password for a CLI two-factor process
+        :param response:
+        :param otp_func:
+        :return: <str> access_token
+        """
+        
+        otp_secret = response['headers'].get('venmo-otp-secret')
+        if not otp_secret:
+            raise AuthenticationFailedError("Failed to get the otp-secret for the 2-factor authentication process. "
+                                            "(check your password)")
+        
+        self.send_text_otp(otp_secret=otp_secret)
+        user_otp = self.__check_otp_validity(otp_func());
+        
+        access_token = self.authenticate_using_otp(user_otp, otp_secret)
+        self.__api_client.update_access_token(access_token=access_token)
+        
         return access_token
 
     def authenticate_using_username_password(self, username: str, password: str) -> dict:
@@ -178,5 +231,12 @@ class AuthenticationApi(object):
             otp = input("Enter OTP that you received on your phone from Venmo: (It must be 6 digits)\n")
 
         return otp
-
-# Making modification to file to test if github works the way I think it does
+    
+    
+    @staticmethod
+    def __check_otp_validity(otp: str):
+    
+        if len(otp) >= 6 and otp.isdigit():
+            return otp
+        else:
+            return __ask_user_for_otp_password()

--- a/venmo_api/apis/auth_api.py
+++ b/venmo_api/apis/auth_api.py
@@ -178,3 +178,5 @@ class AuthenticationApi(object):
             otp = input("Enter OTP that you received on your phone from Venmo: (It must be 6 digits)\n")
 
         return otp
+
+# Making modification to file to test if github works the way I think it does

--- a/venmo_api/apis/auth_api.py
+++ b/venmo_api/apis/auth_api.py
@@ -123,7 +123,9 @@ class AuthenticationApi(object):
                                             "(check your password)")
         
         self.send_text_otp(otp_secret=otp_secret)
-        user_otp = self.__check_otp_validity(otp_func());
+        user_otp = otp_func()
+        while not self.__check_otp_validity(user_otp):
+            user_otp = otp_func()
         
         access_token = self.authenticate_using_otp(user_otp, otp_secret)
         self.__api_client.update_access_token(access_token=access_token)
@@ -232,11 +234,10 @@ class AuthenticationApi(object):
 
         return otp
     
-    
     @staticmethod
     def __check_otp_validity(otp: str):
     
         if len(otp) >= 6 and otp.isdigit():
-            return otp
+            return True
         else:
-            return __ask_user_for_otp_password()
+            return False

--- a/venmo_api/venmo.py
+++ b/venmo_api/venmo.py
@@ -1,4 +1,5 @@
 from venmo_api import ApiClient, UserApi, PaymentApi, AuthenticationApi, validate_access_token
+from collections.abc import Callable, Awaitable
 
 
 class Client(object):
@@ -27,17 +28,23 @@ class Client(object):
         return self.__profile
 
     @staticmethod
-    def get_access_token(username: str, password: str, device_id: str = None) -> str:
+    def get_access_token(username: str, password: str, device_id: str = None, otp_func: Callable[[], str] = None) -> str:
         """
         Log in using your credentials and get an access_token to use in the API
         :param username: <str> Can be username, phone number (without +1) or email address.
         :param password: <str> Account's password
         :param device_id: <str> [optional] A valid device-id.
+        :param otp_func: <Callable[[], str]> [optional] Function to be called when API asks for OTP.
 
         :return: <str> access_token
         """
         authn_api = AuthenticationApi(api_client=ApiClient(), device_id=device_id)
-        return authn_api.login_with_credentials_cli(username=username, password=password)
+        if otp_func == None:
+            return authn_api.login_with_credentials_cli(username=username, password=password)
+        
+        else:
+            return authn_api.login_with_credentials_func(username=username, password=password, otp_func=otp_func)
+        
 
     @staticmethod
     def log_out(access_token) -> bool:


### PR DESCRIPTION
Added functionality for OTP to be provided by a callback function instead of the CLI for use in headless applications. Simply provide a callback function that returns a string as the optional "otp_func" parameter when calling "get_access_token". If two factor authentication is required, your callback function function will be run, and the string it returns will be used used as the OTP. If your function returns a string that is not valid (if it has less than 6 characters or if they're not all numbers) the function will be run repeatedly until a valid string is returned by it (similar to the functionality of the CLI).,