### PR TITLE
Add support for eligibility token in payments

### DIFF
--- a/venmo_api/apis/payment_api.py
+++ b/venmo_api/apis/payment_api.py
@@ -155,6 +155,34 @@ class PaymentApi(object):
                                             target_user=target_user,
                                             callback=callback)
 
+    def __get_eligibility_token(self, amount: float, note: str, target_id: int = None, funding_source_id: str = None,
+                                action: str = "pay",
+                                country_code: str = "1", target_type: str = "user_id", callback=None):
+        """
+        Generate eligibility token which is needed in payment requests
+        :param amount: <float> amount of money to be requested
+        :param note: <str> message/note of the transaction
+        :param target_id: <int> the user id of the person you are sending money to
+        :param funding_source_id: <str> Your payment_method id for this payment
+        :param action: <str> action that eligibility token is used for
+        :param country_code: <str> country code, not sure what this is for
+        :param target_type: <str> set by default to user_id, but there are probably other target types
+        """
+        resource_path = '/protection/eligibility'
+        body = {
+            "funding_source_id": self.get_default_payment_method().id if not funding_source_id else funding_source_id,
+            "action": action,
+            "country_code": country_code,
+            "target_type": target_type,
+            "note": note,
+            "target_id": get_user_id(user=None, user_id=target_id),
+            "amount": amount,
+        }
+
+        return self.__api_client.call_api(resource_path=resource_path,
+                                              body=body,
+                                              method='POST')
+
     def __update_payment(self, action, payment_id):
 
         if not payment_id:

--- a/venmo_api/models/eligibility_token.py
+++ b/venmo_api/models/eligibility_token.py
@@ -1,0 +1,36 @@
+from venmo_api import BaseModel, JSONSchema
+from venmo_api.models.fee import Fee
+
+
+class EligibilityToken(BaseModel):
+    def __init__(self, eligibility_token, eligible, fees, fee_disclaimer, json=None):
+        super().__init__()
+
+        self.eligibility_token = eligibility_token
+        self.eligible = eligible
+        self.fees = fees
+        self.fee_disclaimer = fee_disclaimer
+        self._json = json
+
+    @classmethod
+    def from_json(cls, json):
+        """
+        Initialize a new eligibility token object from JSON.
+        :param json: JSON data to parse.
+        :return: EligibilityToken object.
+        """
+        if not json:
+            return None
+
+        parser = JSONSchema.eligibility_token(json)
+
+        fees = parser.get_fees()
+        fee_objects = [Fee.from_json(fee) for fee in fees] if fees else []
+
+        return cls(
+            eligibility_token=parser.get_eligibility_token(),
+            eligible=parser.get_eligible(),
+            fees=fee_objects,
+            fee_disclaimer=parser.get_fee_disclaimer(),
+            json=json
+        )

--- a/venmo_api/models/fee.py
+++ b/venmo_api/models/fee.py
@@ -1,0 +1,37 @@
+from venmo_api import BaseModel, JSONSchema
+
+
+class Fee(BaseModel):
+    def __init__(self, product_uri, applied_to, base_fee_amount, fee_percentage, calculated_fee_amount_in_cents,
+                 fee_token, json=None):
+        super().__init__()
+
+        self.product_uri = product_uri
+        self.applied_to = applied_to
+        self.base_fee_amount = base_fee_amount
+        self.fee_percentage = fee_percentage
+        self.calculated_fee_amount_in_cents = calculated_fee_amount_in_cents
+        self.fee_token = fee_token
+        self._json = json
+
+    @classmethod
+    def from_json(cls, json):
+        """
+        Initialize a new Fee object from JSON using the FeeParser.
+        :param json: JSON data to parse.
+        :return: Fee object.
+        """
+        if not json:
+            return None
+
+        parser = JSONSchema.fee(json)
+
+        return cls(
+            product_uri=parser.get_product_uri(),
+            applied_to=parser.get_applied_to(),
+            base_fee_amount=parser.get_base_fee_amount(),
+            fee_percentage=parser.get_fee_percentage(),
+            calculated_fee_amount_in_cents=parser.get_calculated_fee_amount_in_cents(),
+            fee_token=parser.get_fee_token(),
+            json=json
+        )

--- a/venmo_api/models/json_schema.py
+++ b/venmo_api/models/json_schema.py
@@ -24,6 +24,14 @@ class JSONSchema:
     def mention(json):
         return MentionParser(json)
 
+    @staticmethod
+    def eligibility_token(json):
+        return EligibilityTokenParser(json)
+
+    @staticmethod
+    def fee(json):
+        return FeeParser(json)
+
 
 class TransactionParser:
 
@@ -323,4 +331,58 @@ class MentionParser:
 mention_json_format = {
     "username": "username",
     "user": "user"
+}
+
+class EligibilityTokenParser:
+    def __init__(self, json):
+        self.json = json
+
+    def get_eligibility_token(self):
+        return self.json.get(eligibility_token_json_format['eligibility_token'])
+
+    def get_eligible(self):
+        return self.json.get(eligibility_token_json_format['eligible'])
+
+    def get_fees(self):
+        return self.json.get(eligibility_token_json_format['fees'])
+
+    def get_fee_disclaimer(self):
+        return self.json.get(eligibility_token_json_format['fee_disclaimer'])
+
+eligibility_token_json_format = {
+    'eligibility_token': 'eligibility_token',
+    'eligible': 'eligible',
+    'fees': 'fees',
+    'fee_disclaimer': 'fee_disclaimer'
+}
+
+class FeeParser:
+    def __init__(self, json):
+        self.json = json
+
+    def get_product_uri(self):
+        return self.json.get(fee_json_format['product_uri'])
+
+    def get_applied_to(self):
+        return self.json.get(fee_json_format['applied_to'])
+
+    def get_base_fee_amount(self):
+        return self.json.get(fee_json_format['base_fee_amount'])
+
+    def get_fee_percentage(self):
+        return self.json.get(fee_json_format['fee_percentage'])
+
+    def get_calculated_fee_amount_in_cents(self):
+        return self.json.get(fee_json_format['calculated_fee_amount_in_cents'])
+
+    def get_fee_token(self):
+        return self.json.get(fee_json_format['fee_token'])
+
+fee_json_format = {
+    'product_uri': 'product_uri',
+    'applied_to': 'applied_to',
+    'base_fee_amount': 'base_fee_amount',
+    'fee_percentage': 'fee_percentage',
+    'calculated_fee_amount_in_cents': 'calculated_fee_amount_in_cents',
+    'fee_token': 'fee_token'
 }

--- a/venmo_api/utils/api_client.py
+++ b/venmo_api/utils/api_client.py
@@ -21,7 +21,7 @@ class ApiClient(object):
         self.access_token = access_token
         self.configuration = {"host": "https://api.venmo.com/v1"}
 
-        self.default_headers = {"User-Agent": "Venmo/7.44.0 (iPhone; iOS 13.0; Scale/2.0)"}
+        self.default_headers = {"User-Agent": "Venmo/10.48.0 (iPhone; iOS 17.6.1; Scale/3.0)"}
         if self.access_token:
             self.default_headers.update({"Authorization": self.access_token})
 

--- a/venmo_api/utils/api_client.py
+++ b/venmo_api/utils/api_client.py
@@ -21,7 +21,7 @@ class ApiClient(object):
         self.access_token = access_token
         self.configuration = {"host": "https://api.venmo.com/v1"}
 
-        self.default_headers = {"User-Agent": "Venmo/10.48.0 (iPhone; iOS 17.6.1; Scale/3.0)"}
+        self.default_headers = {"User-Agent": "Venmo/10.50.0 (iPhone; iOS 18.0; Scale/3.0)"}
         if self.access_token:
             self.default_headers.update({"Authorization": self.access_token})
 


### PR DESCRIPTION
This pull request adds support for eligibility tokens when making payments. It also updates the user agent to match the latest version of the venmo mobile app. It seems like the eligibility token isn't strictly needed, but this should align better with the current behavior of the mobile app.

There's probably some formatting stuff I need to clean up, so let me know how I can fix that.